### PR TITLE
Hide before_action in guest_controller

### DIFF
--- a/app/controllers/guests_controller.rb
+++ b/app/controllers/guests_controller.rb
@@ -1,6 +1,6 @@
 class GuestsController < ApplicationController
   before_action :set_current_guest, except: [:show]
-  before_action :authenticate_user!, except: [:show]
+  # before_action :authenticate_user!, except: [:show]
 
 
   # GET /guests/1


### PR DESCRIPTION
У guest_controller есть before_action :authenticate_user!, except: [:show]
Который после удачной аутентификации редиректит его как User а не как Guest.
Имхо нужно сделать 
$ rails generate devise Guest
что даст хелпер before_action :authenticate_guest!, except: [:show]
по идее исправит проблемы
